### PR TITLE
Fix: allowing all origins with CORS now, FE was still getting a CORS …

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "https://at-finder-my-team-09c8863f.vercel.app/"
+    origins "*"
 
     resource "*",
       headers: :any,


### PR DESCRIPTION
…issue. I think the issue may have been that I had a trailing / on the origin domain for FE, but this will allow us to test the functionality and we can restrict the domain after

## Description

I think the issue with production BE not allowing CORS with FE may have been due to the trailing / I had in the allowed origin. Just to be sure though I opened up CORS for all domain using '*'. If this gets production FE and BE communicating properly we can try to restrict the domains afterward, but I would like to try this first to eliminate any spelling or syntax issues while testing fixes to the problem.

## Type of change

- [ ] fix
- [ ] feat
- [ ] test
- [ ] refactor
- [ ] docs

## Checklist

- [ ] code has been self reviewed
- [ ] code runs without any errors
- [ ] thorough testing has been implemented if adding feature
- [ ] all tests pass

### Thanks!